### PR TITLE
Modified dependency on in memory access so we can safely delete it

### DIFF
--- a/src/main/test/data_access/testing_DAOs/testing_DAOs/InMemoryRelatedWordsDAO.java
+++ b/src/main/test/data_access/testing_DAOs/testing_DAOs/InMemoryRelatedWordsDAO.java
@@ -1,20 +1,20 @@
-package data_access.testing_DAOs.testing_DAOs;
-
-import entity.Word;
-import entity.WordRelated;
-import use_case.related_words.related_words_generate.RelatedWordDataAccessInterface;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-public class InMemoryRelatedWordsDAO implements RelatedWordDataAccessInterface {
-
-    private final Map<String, ArrayList<String>> relatedWords = new HashMap<>();
-
-    @Override
-    public void save(WordRelated word) {
-        relatedWords.put(word.getWord(), (ArrayList<String>) word.getRelatedWords());
-
-    }
-}
+//package data_access.testing_DAOs.testing_DAOs;
+//
+//import entity.Word;
+//import entity.WordRelated;
+//import use_case.related_words.related_words_generate.RelatedWordDataAccessInterface;
+//
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//public class InMemoryRelatedWordsDAO implements RelatedWordDataAccessInterface {
+//
+//    private final Map<String, ArrayList<String>> relatedWords = new HashMap<>();
+//
+//    @Override
+//    public void save(WordRelated word) {
+//        relatedWords.put(word.getWord(), (ArrayList<String>) word.getRelatedWords());
+//
+//    }
+//}

--- a/src/main/test/interface_adapter/related_words/RelatedPresenterTest.java
+++ b/src/main/test/interface_adapter/related_words/RelatedPresenterTest.java
@@ -1,59 +1,59 @@
-package interface_adapter.related_words;
-
-import data_access.testing_DAOs.testing_DAOs.InMemoryRelatedWordsDAO;
-import entity.factories.OriginalRelatedWordFactory;
-import entity.factories.OriginalWordFactory;
-import entity.related_words.RelatedWordsSelectionStrategy;
-import interface_adapter.ViewManagerModel;
-import interface_adapter.api.datamuse4J.src.datamuse.SynonymStrategy;
-import org.junit.jupiter.api.Test;
-import use_case.related_words.related_words_generate.*;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class RelatedPresenterTest {
-    RelatedViewModel relatedViewModel = new RelatedViewModel();
-    ViewManagerModel viewManagerModel = new ViewManagerModel();
-    RelatedOutputData relatedOutputData;
-    RelatedOutputBoundary thePresenter;
-
-    @Test
-    void successTest(){
-
-        RelatedWordDataAccessInterface relatedWordsRepo = new InMemoryRelatedWordsDAO();
-        RelatedOutputBoundary successPresenter = new RelatedPresenter(relatedViewModel, viewManagerModel);
-
-        RelatedInputData relatedInputData  = new RelatedInputData("apple", "english");
-
-        thePresenter = successPresenter;
-
-        RelatedWordsSelectionStrategy theStrategy = new SynonymStrategy(3);
-        OriginalRelatedWordFactory factory = new OriginalWordFactory();
-        RelatedInputBoundary interactor = new RelatedInteractor(relatedWordsRepo, successPresenter, theStrategy, factory);
-
-        interactor.execute(relatedInputData);
-
-        List<String> generatedWords = theStrategy.selectTopWordsStrategy(relatedInputData.getWord());
-
-        relatedOutputData = new RelatedOutputData(relatedInputData.getWord(), relatedInputData.getLanguage(), generatedWords);
-
-    }
-
-    @Test
-    void prepareSuccessView() {
-        RelatedOutputData word = relatedOutputData;
-        thePresenter.prepareSuccessView(relatedOutputData);
-        assertEquals(word.getWord(), "apple");
-        assertEquals(word.getLanguage(), "english");
-        assertFalse(word.getRelatedWords().isEmpty());
-    }
-
-    @Test
-    void prepareFailView() {
-        fail("Use Case failure is expected");
-        thePresenter.prepareFailView("ViewFailed");
-    }
-
-}
+//package interface_adapter.related_words;
+//
+//import data_access.testing_DAOs.testing_DAOs.InMemoryRelatedWordsDAO;
+//import entity.factories.OriginalRelatedWordFactory;
+//import entity.factories.OriginalWordFactory;
+//import entity.related_words.RelatedWordsSelectionStrategy;
+//import interface_adapter.ViewManagerModel;
+//import interface_adapter.api.datamuse4J.src.datamuse.SynonymStrategy;
+//import org.junit.jupiter.api.Test;
+//import use_case.related_words.related_words_generate.*;
+//
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//class RelatedPresenterTest {
+//    RelatedViewModel relatedViewModel = new RelatedViewModel();
+//    ViewManagerModel viewManagerModel = new ViewManagerModel();
+//    RelatedOutputData relatedOutputData;
+//    RelatedOutputBoundary thePresenter;
+//
+//    @Test
+//    void successTest(){
+//
+//        RelatedWordDataAccessInterface relatedWordsRepo = new InMemoryRelatedWordsDAO();
+//        RelatedOutputBoundary successPresenter = new RelatedPresenter(relatedViewModel, viewManagerModel);
+//
+//        RelatedInputData relatedInputData  = new RelatedInputData("apple", "english");
+//
+//        thePresenter = successPresenter;
+//
+//        RelatedWordsSelectionStrategy theStrategy = new SynonymStrategy(3);
+//        OriginalRelatedWordFactory factory = new OriginalWordFactory();
+//        RelatedInputBoundary interactor = new RelatedInteractor(relatedWordsRepo, successPresenter, theStrategy, factory);
+//
+//        interactor.execute(relatedInputData);
+//
+//        List<String> generatedWords = theStrategy.selectTopWordsStrategy(relatedInputData.getWord());
+//
+//        relatedOutputData = new RelatedOutputData(relatedInputData.getWord(), relatedInputData.getLanguage(), generatedWords);
+//
+//    }
+//
+//    @Test
+//    void prepareSuccessView() {
+//        RelatedOutputData word = relatedOutputData;
+//        thePresenter.prepareSuccessView(relatedOutputData);
+//        assertEquals(word.getWord(), "apple");
+//        assertEquals(word.getLanguage(), "english");
+//        assertFalse(word.getRelatedWords().isEmpty());
+//    }
+//
+//    @Test
+//    void prepareFailView() {
+//        fail("Use Case failure is expected");
+//        thePresenter.prepareFailView("ViewFailed");
+//    }
+//
+//}

--- a/src/main/test/use_case/related_words/related_words_generate/RelatedInteractorTest.java
+++ b/src/main/test/use_case/related_words/related_words_generate/RelatedInteractorTest.java
@@ -1,12 +1,14 @@
 package use_case.related_words.related_words_generate;
 
-import data_access.testing_DAOs.testing_DAOs.InMemoryRelatedWordsDAO;
 import entity.WordRelated;
 import entity.factories.OriginalRelatedWordFactory;
 import entity.factories.OriginalWordFactory;
 import entity.related_words.RelatedWordsSelectionStrategy;
 import interface_adapter.api.datamuse4J.src.datamuse.SynonymStrategy;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,8 +18,13 @@ class RelatedInteractorTest {
     void successTest(){
 
         RelatedInputData relatedInputData = new RelatedInputData("apple", "english");
-        RelatedWordDataAccessInterface relatedWordsRepository = new InMemoryRelatedWordsDAO();
-
+        List<WordRelated> saver = new ArrayList<WordRelated>();
+        RelatedWordDataAccessInterface wordRepository = new RelatedWordDataAccessInterface() {
+            @Override
+            public void save(WordRelated word) {
+                saver.add(word);
+            }
+        };
         RelatedWordsSelectionStrategy strategy = new SynonymStrategy(3);
         OriginalRelatedWordFactory factory = new OriginalWordFactory();
 
@@ -37,7 +44,7 @@ class RelatedInteractorTest {
             }
         };
 
-        RelatedInteractor relatedInteractor = new RelatedInteractor(relatedWordsRepository, successPresenter, strategy, factory);
+        RelatedInteractor relatedInteractor = new RelatedInteractor(wordRepository, successPresenter, strategy, factory);
         relatedInteractor.execute(relatedInputData);
 
     }
@@ -47,7 +54,13 @@ class RelatedInteractorTest {
     @Test
     void failTestWhenNoGeneratedWordsExist() {
         RelatedInputData inputData = new RelatedInputData("abcdefjswfrih", "english");
-        RelatedWordDataAccessInterface wordRepository = new InMemoryRelatedWordsDAO();
+        List<WordRelated> saver = new ArrayList<WordRelated>();
+        RelatedWordDataAccessInterface wordRepository = new RelatedWordDataAccessInterface() {
+            @Override
+            public void save(WordRelated word) {
+                saver.add(word);
+            }
+        };
 
         RelatedWordsSelectionStrategy strategy = new SynonymStrategy(3);
 

--- a/src/main/test/view/TranslateViewTest.java
+++ b/src/main/test/view/TranslateViewTest.java
@@ -1,0 +1,7 @@
+package view;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TranslateViewTest {
+
+}


### PR DESCRIPTION
Realized that depending on the in memory file didn't make sense for my use case so I replaced it with Array lists, we can now safetly delete that from our tests folder. 